### PR TITLE
Updated the ASM to use NASM instead of MASM

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,9 @@ This is the code of RPL's GPS system. There are three components to this code.
 ## FPGA Programming
 
 The FPGA is programmed by the Raspberry Pi every time on startup. The Verilog is
-found in the Xilinx folder.
+found in the Xilinx folder. The layout for the FPGA is generated in the Xilinx
+ISE software. Note that the windows 10 version of the ISE does not support the
+Spartan 3 FPGA we are using.
 
 
 ## Raspberry PI
@@ -19,8 +21,7 @@ source on any PI which is to run this code. The latest version of the software
 will work and can be downloaded at
 [www.fftw.org/download.html](http://www.fftw.org/download.html).
 
-After installing the FFTW3 library building the source requires the following
-commands.
+After installing the FFTW3 library the source can be built with:
 
 ```bash
 $ cd C++/
@@ -29,3 +30,16 @@ $ cd build/
 $ cmake ..
 $ make
 ```
+
+## Soft-core (in FPGA) cpu assembly
+
+In addition to the FPGA layout and Raspberry pi code there is a program that
+runs on a CPU built into the FPGA layout. The source can be found in the ASM
+sub directory. To build the executable simply compile with NASM.
+
+```bash
+$ cd asm
+$ nasm GPS44.asm
+```
+
+The executable will be a file called GPS44 in the same directory.

--- a/asm/GPS44.asm
+++ b/asm/GPS44.asm
@@ -1,5 +1,6 @@
 ; ============================================================================
 ; Homemade GPS Receiver
+; Copyright (C) 2018 Max Apodaca
 ; Copyright (C) 2013 Andrew Holme
 ;
 ; This program is free software: you can redistribute it and/or modify


### PR DESCRIPTION
The ASM now uses NASM syntax instead of MASM as MASM is not nicely available for Linux.